### PR TITLE
Enhance calendar layout with scroll support

### DIFF
--- a/src/components/AttendanceGrid.tsx
+++ b/src/components/AttendanceGrid.tsx
@@ -75,7 +75,7 @@ const AttendanceGrid: React.FC = () => {
         <th
           key={day}
           className={clsx(
-            'w-8 h-12 text-xs border border-gray-300 relative',
+            'w-10 h-12 text-xs border border-gray-300 relative',
             isWeekend && isValidDay ? 'bg-gray-200' : 'bg-white',
             !isValidDay && 'bg-gray-100'
           )}
@@ -171,7 +171,7 @@ const AttendanceGrid: React.FC = () => {
 
       <div className="flex">
         {/* Main Grid */}
-        <div className="flex-1 overflow-x-auto">
+        <div className="flex-1 overflow-auto max-h-[70vh]">
           <table className="w-full border-collapse">
             <thead>
               <tr>

--- a/src/components/PupilRow.tsx
+++ b/src/components/PupilRow.tsx
@@ -93,7 +93,7 @@ const PupilRow: React.FC<PupilRowProps> = ({
         <td
           key={day}
           className={clsx(
-            'w-8 h-8 border border-gray-300 relative p-0',
+            'w-10 h-10 border border-gray-300 relative p-0',
             isWeekend && isValidDay ? 'bg-gray-100' : 'bg-white',
             !isValidDay && 'bg-gray-50'
           )}


### PR DESCRIPTION
## Summary
- enlarge calendar cells for better readability
- allow scrolling vertically in the main grid area

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d32ed1c7c8328b5c81757fd69237f