### PR TITLE
Double grid cell size for better readability

### DIFF
--- a/src/components/AttendanceGrid.tsx
+++ b/src/components/AttendanceGrid.tsx
@@ -75,7 +75,7 @@ const AttendanceGrid: React.FC = () => {
         <th
           key={day}
           className={clsx(
-            'w-8 h-12 text-xs border border-gray-300 relative',
+            'w-20 h-16 text-sm border border-gray-300 relative',
             isWeekend && isValidDay ? 'bg-gray-200' : 'bg-white',
             !isValidDay && 'bg-gray-100'
           )}
@@ -171,14 +171,14 @@ const AttendanceGrid: React.FC = () => {
 
       <div className="flex">
         {/* Main Grid */}
-        <div className="flex-1 overflow-x-auto">
+        <div className="flex-1 overflow-auto max-h-[70vh]">
           <table className="w-full border-collapse">
             <thead>
               <tr>
-                <th className="w-12 h-12 bg-sky-100 border border-gray-300 text-xs font-bold">
+                <th className="w-16 h-16 bg-sky-100 border border-gray-300 text-sm font-bold">
                   N°
                 </th>
-                <th className="w-64 h-12 bg-sky-100 border border-gray-300 text-xs font-bold text-left px-2">
+                <th className="w-96 h-16 bg-sky-100 border border-gray-300 text-sm font-bold text-left px-2">
                   Nom et prénom(s) des élèves
                 </th>
                 {renderDayHeaders()}

--- a/src/components/PupilRow.tsx
+++ b/src/components/PupilRow.tsx
@@ -93,7 +93,7 @@ const PupilRow: React.FC<PupilRowProps> = ({
         <td
           key={day}
           className={clsx(
-            'w-8 h-8 border border-gray-300 relative p-0',
+            'w-20 h-16 border border-gray-300 relative p-0',
             isWeekend && isValidDay ? 'bg-gray-100' : 'bg-white',
             !isValidDay && 'bg-gray-50'
           )}
@@ -138,12 +138,12 @@ const PupilRow: React.FC<PupilRowProps> = ({
   return (
     <tr className="hover:bg-gray-50">
       {/* Row Number */}
-      <td className="w-12 h-8 bg-sky-50 border border-gray-300 text-center text-sm font-medium">
+      <td className="w-16 h-12 bg-sky-50 border border-gray-300 text-center text-sm font-medium">
         {rowNumber}
       </td>
       
       {/* Pupil Name */}
-      <td className="w-64 h-8 border border-gray-300 px-2 text-sm">
+      <td className="w-96 h-12 border border-gray-300 px-2 text-sm">
         {pupil ? (
           <div className="flex items-center justify-between">
             <button


### PR DESCRIPTION
## Summary
- enlarge header and day cell dimensions to make calendar twice as big
- adjust row number and name columns to match increased scale

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d32ed1c7c8328b5c81757fd69237f